### PR TITLE
Introduced apple-based `clock_gettime`

### DIFF
--- a/tests/time-tests/NanoSleepTest.cpp
+++ b/tests/time-tests/NanoSleepTest.cpp
@@ -4,10 +4,14 @@
 
 #include <iostream>
 
+extern "C" {
+int _clock_gettime_impl(clockid_t clk_id, struct timespec *tp);
+}
+
 TEST(NanoSleepTest, 01_monotonic_clock) {
   struct timespec now, then;
 
-  assert(clock_gettime(CLOCK_REALTIME, &now) == 0);
+  assert(_clock_gettime_impl(CLOCK_MONOTONIC, &now) == 0);
 
   struct timespec deadline;
   clock_gettime(CLOCK_MONOTONIC, &deadline);
@@ -22,7 +26,7 @@ TEST(NanoSleepTest, 01_monotonic_clock) {
   int status = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &deadline, NULL);
   ASSERT_EQ(status, 0);
 
-  assert(clock_gettime(CLOCK_REALTIME, &then) == 0);
+  assert(_clock_gettime_impl(CLOCK_MONOTONIC, &then) == 0);
   auto diff = then.tv_sec - now.tv_sec;
   ASSERT_EQ(diff, 1);
 }
@@ -34,12 +38,12 @@ TEST(NanoSleepTest, 02_realtime_clock) {
   deadline.tv_sec = 1;
   deadline.tv_nsec = 0;
 
-  assert(clock_gettime(CLOCK_REALTIME, &now) == 0);
+  assert(_clock_gettime_impl(CLOCK_REALTIME, &now) == 0);
 
   int status = clock_nanosleep(CLOCK_REALTIME, 0, &deadline, NULL);
   ASSERT_EQ(status, 0);
 
-  assert(clock_gettime(CLOCK_REALTIME, &then) == 0);
+  assert(_clock_gettime_impl(CLOCK_REALTIME, &then) == 0);
 
   auto diff = then.tv_sec - now.tv_sec;
   ASSERT_EQ(diff, 1);


### PR DESCRIPTION
Here a bit ugly implementation which is based on fallback from apple's libc.

This `clock_gettime` is also included into existed unit tests.